### PR TITLE
19 edit current task description

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -35,6 +35,13 @@ document.addEventListener('DOMContentLoaded', () => {
         const data = storage.get(storage.entities.CURRENT_TASK_DATA);
         screenManager.showResolvingStep(data);
     });
+    storage.beforeUpdate(storage.entities.CURRENT_TASK_DATA, () => {
+        screenManager.showEditStep();
+    });
+    storage.afterUpdate(storage.entities.CURRENT_TASK_DATA, () => {
+        const data = storage.get(storage.entities.CURRENT_TASK_DATA);
+        screenManager.hideEditStep(data);
+    });
     storage.onRemove(storage.entities.CURRENT_TASK_DATA, () => {
         screenManager.hideResolvingStep();
         screenManager.showInitialStep();

--- a/src/js/screenManager.js
+++ b/src/js/screenManager.js
@@ -12,6 +12,13 @@ export const screenManager = {
 
         this._currentStep++;
     },
+    showEditStep() {
+        this._ds.initForm('edit');
+    },
+    hideEditStep(data) {
+        this._ds.destroyForm();
+        this._ds.renderView(data);
+    },
     showResolvingStep(data) {
         this._ds.destroyForm();
         if (this._currentStep) this._ds.destroyCell();

--- a/src/js/storageService.js
+++ b/src/js/storageService.js
@@ -62,7 +62,7 @@ StorageService.prototype.get = function(entity) {
  * устанавливает значение ключа в Storage и публикует соответствующее ему событие(опционально)
  * @param {entities} entity - название ключа из Storage
  */
-StorageService.prototype.set = function(entity, data, createEvent = true) {
+StorageService.prototype.set = function(entity, data, createEvent = true, eventType = 'created') {
     const config = this[_getConfig](entity);
     const storage = this[_getStorage](config.storage);
 
@@ -70,7 +70,7 @@ StorageService.prototype.set = function(entity, data, createEvent = true) {
 
     storage.setItem(config.key, data);
 
-    if (createEvent) eventBus.dispatch(this[_getEventName](entity, 'created'));
+    if (createEvent) eventBus.dispatch(this[_getEventName](entity, eventType));
 }
 /**
  * устанавливает данные по ключу в Storage и публикует соответствующее ему событие(опционально)
@@ -91,12 +91,28 @@ StorageService.prototype.remove = function(entity, createEvent = true) {
     if (createEvent) eventBus.dispatch(this[_getEventName](entity, 'deleted'));
 }
 /**
- * хук для отлова опубликованного события обновления Storage
+ * хук для отлова опубликованного события создания сущности в Storage
  * @param {entities} entity - название ключа из Storage
  * @param {function} cb - коллбэк-функция, которая триггерится во время события
  */
 StorageService.prototype.onCreate = function(entity, cb) {
     eventBus.listen(this[_getEventName](entity, 'created'), cb);
+}
+/**
+ * хук для отлова опубликованного события перед изменением сущности в Storage
+ * @param {entities} entity - название ключа из Storage
+ * @param {function} cb - коллбэк-функция, которая триггерится во время события
+ */
+StorageService.prototype.beforeUpdate = function(entity, cb) {
+    eventBus.listen(this[_getEventName](entity, 'update'), cb);
+}
+/**
+ * хук для отлова опубликованного события после изменения сущности в Storage
+ * @param {entities} entity - название ключа из Storage
+ * @param {function} cb - коллбэк-функция, которая триггерится во время события
+ */
+StorageService.prototype.afterUpdate = function(entity, cb) {
+    eventBus.listen(this[_getEventName](entity, 'updated'), cb);
 }
 /**
  * хук для отлова опубликованного события удаленного ключа с данными из Storage

--- a/src/js/tasksService.js
+++ b/src/js/tasksService.js
@@ -34,7 +34,7 @@ export const taskManager = {
         const currentTask = JSON.parse(this[_storage].get(this[_storage].entities.CURRENT_TASK_DATA));
         const {name, text, code} = data;
         const updatedTask = new ITask(currentTask.id, name ?? currentTask.name, text ?? currentTask.text, code ?? currentTask.code, currentTask.startDate);
-        this[_storage].set(this[_storage].entities.CURRENT_TASK_DATA, updatedTask, false);
+        this[_storage].set(this[_storage].entities.CURRENT_TASK_DATA, updatedTask, true, 'updated');
     },
     /**
      * Сохраняет текущую задачу в коллекцию-архив


### PR DESCRIPTION
добавил черновую рабочую логику для изменения данных в current-task-data из LS в рамках MVP. В будущем может потребоваться рефакторинг, ибо для добавления одной фичи пришлось затрагивать несколько сторонних сервисов и менять/дорабатывать их логику, что не есть хорошо (неортогональная система). Возможно, стоит напрямую использовать шину событий в сервисах и убрать привязку к StorageService ради абстрагирования и избегания прописывать название событий вручную (например, когда я захочу от Storage перейти к клиент-серверной архитектуре)